### PR TITLE
Fix for DateTimeKind.Unspecified

### DIFF
--- a/KunaApi/KunaApi/KunaTrade.cs
+++ b/KunaApi/KunaApi/KunaTrade.cs
@@ -28,7 +28,7 @@ namespace KunaApi
                 Volume = Convert.ToDouble((json["volume"] as JValue).Value.ToString(), CultureInfo.InvariantCulture),
                 Funds = json["funds"] != null ? Convert.ToDouble((json["funds"] as JValue).Value.ToString(), CultureInfo.InvariantCulture) : 0,
                 Market = (json["id"] as JValue).Value.ToString(),
-                CreatedAt = DateTime.Parse((json["created_at"] as JValue).Value.ToString()),
+                CreatedAt = (DateTime)((json["created_at"] as JValue).Value),
                 Side = (json["side"] as JValue).Value != null ? (json["side"] as JValue).Value.ToString() : "null"
             };
         }


### PR DESCRIPTION
Sometimes Kuna returns Utc Datetime, sometimes with time zone specified. We should store DateTime Kind.